### PR TITLE
Honor RAILS_ENV/BP_BUNDLE_WITHOUT to skip dev/test gems from build cache

### DIFF
--- a/build.go
+++ b/build.go
@@ -123,10 +123,14 @@ func Build(
 				logger.Process("Executing build environment install process")
 
 				duration, err := clock.Measure(func() error {
-					return installProcess.Execute(context.WorkingDir, layer.Path, map[string]string{
+					buildConfig := map[string]string{
 						"path":  layer.Path,
 						"clean": "true",
-					}, environment.KeepGemExtensionBuildFiles)
+					}
+					if environment.BundleWithout != "" {
+						buildConfig["without"] = environment.BundleWithout
+					}
+					return installProcess.Execute(context.WorkingDir, layer.Path, buildConfig, environment.KeepGemExtensionBuildFiles)
 				})
 				if err != nil {
 					return packit.BuildResult{}, err
@@ -214,9 +218,13 @@ func Build(
 						}
 					}
 
+					launchWithout := "development:test"
+					if environment.BundleWithout != "" {
+						launchWithout = environment.BundleWithout
+					}
 					return installProcess.Execute(context.WorkingDir, layer.Path, map[string]string{
 						"path":    layer.Path,
-						"without": "development:test",
+						"without": launchWithout,
 						"clean":   "true",
 					}, environment.KeepGemExtensionBuildFiles)
 				})

--- a/build_test.go
+++ b/build_test.go
@@ -239,6 +239,33 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(installProcess.ExecuteCall.Receives.KeepBuildFiles).To(BeTrue())
 			})
 		})
+
+		context("when BundleWithout is set", func() {
+			it.Before(func() {
+				build = bundleinstall.Build(
+					entryResolver,
+					installProcess,
+					sbomGenerator,
+					scribe.NewEmitter(buffer),
+					clock,
+					bundleinstall.Environment{
+						BundleWithout: "development:test",
+					},
+				)
+			})
+
+			it("passes the without config to the build install", func() {
+				_, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(installProcess.ExecuteCall.CallCount).To(Equal(1))
+				Expect(installProcess.ExecuteCall.Receives.Config).To(Equal(map[string]string{
+					"path":    filepath.Join(layersDir, "build-gems"),
+					"without": "development:test",
+					"clean":   "true",
+				}))
+			})
+		})
 	})
 
 	context("when required during launch", func() {
@@ -391,6 +418,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(installProcess.ExecuteCall.Receives.KeepBuildFiles).To(BeTrue())
 			})
 		})
+
 	})
 
 	context("when not required during either build or launch", func() {
@@ -576,6 +604,38 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			content, err = os.ReadFile(filepath.Join(layersDir, "launch-gems", "ruby", "some-file"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(Equal("some-file-contents"))
+		})
+
+		context("when BundleWithout is set", func() {
+			it.Before(func() {
+				build = bundleinstall.Build(
+					entryResolver,
+					installProcess,
+					sbomGenerator,
+					scribe.NewEmitter(buffer),
+					clock,
+					bundleinstall.Environment{
+						BundleWithout: "production:test:staging:heroku",
+					},
+				)
+			})
+
+			it("applies the without config to both the build and launch installs", func() {
+				_, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(installProcess.ExecuteCall.CallCount).To(Equal(2))
+
+				// The InstallProcess fake only retains the last invocation in
+				// `Receives`, so we assert on the launch (second) invocation
+				// here. Earlier `Build`-only contexts already cover the
+				// build-layer config under the same code path.
+				Expect(installProcess.ExecuteCall.Receives.Config).To(Equal(map[string]string{
+					"path":    filepath.Join(layersDir, "launch-gems"),
+					"without": "production:test:staging:heroku",
+					"clean":   "true",
+				}))
+			})
 		})
 	})
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -7,7 +7,7 @@ api = "0.7"
   keywords = ["ruby", "bundler"]
   name = "Paketo Buildpack for Bundle Install"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
-  version = "0.8.18"
+  version = "0.9.0"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"

--- a/environment.go
+++ b/environment.go
@@ -8,10 +8,31 @@ import (
 
 type Environment struct {
 	KeepGemExtensionBuildFiles bool
+	// BundleWithout is the colon-separated list of Bundler groups to exclude
+	// from `bundle install` in BOTH the build and launch layers. When empty,
+	// the build layer installs all groups (legacy behaviour) and the launch
+	// layer falls back to its hardcoded "development:test" default.
+	BundleWithout string
 }
 
+// ParseEnvironment reads the relevant BP_* and runtime env variables and
+// returns the resolved Environment.
+//
+// BundleWithout precedence:
+//  1. Explicit BP_BUNDLE_WITHOUT (highest priority).
+//  2. Derived from RAILS_ENV / RACK_ENV (RAILS_ENV wins if both set):
+//     - production | staging   -> "development:test"
+//     - development            -> "production:test:staging:heroku"
+//     - test                   -> "production:development:staging:heroku"
+//     - any other / unset      -> "" (legacy behaviour, install everything in build)
 func ParseEnvironment(environ []string) (Environment, error) {
 	var environment Environment
+	var (
+		explicitWithout string
+		railsEnv        string
+		rackEnv         string
+	)
+
 	for _, variable := range environ {
 		if value, found := strings.CutPrefix(variable, "BP_KEEP_GEM_EXTENSION_BUILD_FILES="); found {
 			var err error
@@ -20,7 +41,40 @@ func ParseEnvironment(environ []string) (Environment, error) {
 				return Environment{}, fmt.Errorf("failed to parse BP_KEEP_GEM_EXTENSION_BUILD_FILES: %w", err)
 			}
 		}
+		if value, found := strings.CutPrefix(variable, "BP_BUNDLE_WITHOUT="); found {
+			explicitWithout = value
+		}
+		if value, found := strings.CutPrefix(variable, "RAILS_ENV="); found {
+			railsEnv = value
+		}
+		if value, found := strings.CutPrefix(variable, "RACK_ENV="); found {
+			rackEnv = value
+		}
+	}
+
+	switch {
+	case explicitWithout != "":
+		environment.BundleWithout = explicitWithout
+	default:
+		appEnv := railsEnv
+		if appEnv == "" {
+			appEnv = rackEnv
+		}
+		environment.BundleWithout = defaultBundleWithoutFor(appEnv)
 	}
 
 	return environment, nil
+}
+
+func defaultBundleWithoutFor(appEnv string) string {
+	switch appEnv {
+	case "production", "staging":
+		return "development:test"
+	case "development":
+		return "production:test:staging:heroku"
+	case "test":
+		return "production:development:staging:heroku"
+	default:
+		return ""
+	}
 }

--- a/environment_test.go
+++ b/environment_test.go
@@ -33,6 +33,88 @@ func testEnvironment(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when BP_BUNDLE_WITHOUT is set explicitly", func() {
+			it("uses the explicit value", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"BP_BUNDLE_WITHOUT=development:test:assets",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("development:test:assets"))
+			})
+
+			it("wins over RAILS_ENV-derived default", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"BP_BUNDLE_WITHOUT=custom:groups",
+					"RAILS_ENV=production",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("custom:groups"))
+			})
+		})
+
+		context("when RAILS_ENV is set", func() {
+			it("derives 'development:test' for production", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RAILS_ENV=production",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("development:test"))
+			})
+
+			it("derives 'development:test' for staging", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RAILS_ENV=staging",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("development:test"))
+			})
+
+			it("derives 'production:test:staging:heroku' for development", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RAILS_ENV=development",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("production:test:staging:heroku"))
+			})
+
+			it("derives 'production:development:staging:heroku' for test", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RAILS_ENV=test",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("production:development:staging:heroku"))
+			})
+
+			it("falls back to empty for unrecognized values", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RAILS_ENV=somethingweird",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal(""))
+			})
+		})
+
+		context("when only RACK_ENV is set", func() {
+			it("derives 'development:test' for production", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RACK_ENV=production",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("development:test"))
+			})
+		})
+
+		context("when both RAILS_ENV and RACK_ENV are set", func() {
+			it("RAILS_ENV wins", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"RAILS_ENV=production",
+					"RACK_ENV=development",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment.BundleWithout).To(Equal("development:test"))
+			})
+		})
+
 		context("failure cases", func() {
 			context("when the BP_KEEP_GEM_EXTENSION_BUILD_FILES env var cannot be parsed", func() {
 				it("returns an error", func() {


### PR DESCRIPTION
Fixes: https://github.com/neetozone/neeto-deploy-web/issues/7146

## Summary

The `build-gems` cache layer was carrying every gem in the `Gemfile`, including `:development` and `:test` groups, even though the launch image correctly excludes them. Inspection of `neeto-planner-web-staging`'s `:cache` ECR image (3.04 GB uncompressed) showed:

| Bucket | Size (uncompressed) |
|---|---|
| `wkhtmltopdf-binary` (`:development, :test` group, 2 cached versions) | 1,134 MB |
| Other dev/test gems (brakeman, faker, rbs, prism, rubocop, ruby_parser, …) | ~152 MB |
| **Total dev/test pollution** | **~1,286 MB** |

The exporter still has to extract + gzip + SHA256 the entire 2.65 GB compressed `build-gems` layer on every build (~85 s/build) — even when nothing changed.

## Root cause

In `build.go`, the **build-layer** install runs with no `without` config, while the **launch-layer** install hardcodes `\"without\": \"development:test\"`. Once dev/test gems land in the build-gems cache, they stay there forever — subsequent builds \"Reuse cached layer\" without re-installing.

## Change

Adds two env knobs honored by **both** layer installs:

- **`BP_BUNDLE_WITHOUT`** — explicit override (highest priority)
- **`RAILS_ENV` / `RACK_ENV`** — derives a default:
  - `production` | `staging` → `\"development:test\"`
  - `development` → `\"production:test:staging:heroku\"`
  - `test` → `\"production:development:staging:heroku\"`
  - anything else / unset → `\"\"` (preserves existing behaviour)

Defaults preserve back-compat: when neither knob is set, the build layer still installs everything and the launch layer still strips dev/test.

## Files

- `environment.go` — new `BundleWithout` field + parsing logic.
- `build.go` — both layer install sites now honor `environment.BundleWithout`.
- `environment_test.go` — 9 new cases (BP_ explicit, BP_ vs RAILS_ENV precedence, each RAILS_ENV value, RACK_ENV fallback, RAILS_ENV wins over RACK_ENV).
- `build_test.go` — 2 new contexts: build-only `BundleWithout`, and combined build+launch `BundleWithout` (asserts launch invocation overrides hardcoded default).
- `buildpack.toml` — `0.8.18` → `0.9.0`.

## Versioning

`0.9.0` (minor — new env-driven feature, defaults preserve back-compat).

## Test plan

- [x] All 11 new unit tests pass.
- [x] No regression vs `main`: pre-existing failures unchanged (9 failures on both `main` and this branch — Detect tests + launch-only Build tests broken since `0b9a148`, unrelated to this change).
- [x] `go build ./...` succeeds.
- [x] Multi-arch buildpack image published to ECR as `348674388966.dkr.ecr.us-east-1.amazonaws.com/neeto-deploy/paketo/buildpack/bundle-install:0.9.0` (manifest list w/ `0.9.0-amd64` + `0.9.0-arm64`).

## Expected savings

- ~600 MB compressed reduction in the build-gems layer
- ~25–30 s/build saved on EXPORT phase
- Same fix benefits **every** Ruby app on neeto-deploy that imports `Gemfile.common.rb` (the `wkhtmltopdf-binary` placement in `:development, :test` is shared across products)

## Out of scope (separate follow-up)

Wiring the new buildpack into the build pipeline — either rebuild the builder image (`paketo-builders/jammy:v1`, etc.) or override at the slug-compiler level via `DEFAULT_BUILDPACKS` `--buildpack` flag in `neeto-deploy-slug-compiler-web/app/services/slug_compiler/pack_build_service.rb`.

Refs: neetozone/neeto-deploy-web#7146

🤖 Generated with [Claude Code](https://claude.com/claude-code)